### PR TITLE
pycocotools fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,6 @@ conda install pytorch==1.7.0 torchvision==0.8.0 torchaudio==0.7.0 cudatoolkit=10
 pip install -r requirements.txt
 export PYTHONPATH=$PWD:$PYTHONPATH
 ```
-Step2. Install [pycocotools](https://github.com/cocodataset/cocoapi).
-
-```shell
-pip install cython;
-pip install git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI # for Linux
-pip install git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI # for Windows
-```
 </details>
 
 <details>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Pillow
 thop
 tabulate
 easydict
+pycocotools


### PR DESCRIPTION
- by installing from original repo of pycocotools (2019), it depends on numpy version 1.x.x
- current version of pytorch and other libraries requires numpy 2.x.x
- to train model it is not possible to use installation method described in readme
- install fix version of pycocotools (https://pypi.org/project/pycocotools/)